### PR TITLE
Re-emplaza colombia.dev con Perú Dev y agrega atribución a colombia.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ evento de pago).
 Si eres víctima o testigo de una conducta inaceptable, o tienes cualquier
 inquietud, por favor comunícate con un organizador del meetup lo antes posible.
 
-Email: hola@peru-dev.org
+Email: peru.develop@gmail.com
 
 Adicionalmente, los organizadores comunitarios están disponibles para ayudar
 a miembros de la comunidad a contactar a la policía local o interceder para que
@@ -149,7 +149,7 @@ comunicaciones de uno-a-uno pertinentes a los negocios de la comunidad.
 
 ## 9. Contacto
 
-- hola@peru-dev.org
+- peru.develop@gmail.com
 - [@peru_dev](https://twitter.com/peru_dev)
 
 ## 10. Licencia y atribución

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# [colombia.dev] - Código de Conducta
+# [Perú Dev] - Código de Conducta
 
 ## 1. Propósito
 
-Uno de los objetivos principales de `colombia.dev` es ser inclusiva para el 
+Uno de los objetivos principales de `Perú Dev` es ser inclusiva para el
 mayor número de contribuyentes, con la mayor diversidad de orígenes posibles.
 Como tal, estamos comprometidos a proporcionar un ambiente agradable, seguro y
-acogedor para todos, independientemente de su sexo, orientación sexual, 
+acogedor para todos, independientemente de su sexo, orientación sexual,
 capacidad, etnia, nivel socioeconómico, y religión (o falta de la misma).
 
-Este código de conducta resume nuestras expectativas para todos los que 
-participan en nuestra comunidad, así como las consecuencias para el 
+Este código de conducta resume nuestras expectativas para todos los que
+participan en nuestra comunidad, así como las consecuencias para el
 comportamiento inaceptable.
 
-Invitamos a todos los que participan en `colombia.dev` a que nos ayuden a crear
+Invitamos a todos los que participan en `Perú Dev` a que nos ayuden a crear
 experiencias seguras y positivas para todos.
 
 ## 2. Ciudadanía de [Software / Cultura / Tecnología] Libre
 
-Un objetivo adicional de este Código de Conducta es aumentar la ciudadanía de 
+Un objetivo adicional de este Código de Conducta es aumentar la ciudadanía de
 [software / cultura / tecnología] libre mediante el fomento de los participantes
-a reconocer y fortalecer las relaciones entre nuestras acciones y sus efectos en 
+a reconocer y fortalecer las relaciones entre nuestras acciones y sus efectos en
 nuestra comunidad.
 
 Las comunidades reflejan las sociedades en las que existen y la acción positiva
@@ -32,32 +32,32 @@ todos los participantes a que contribuyan en la mayor medida, nos gustaría sabe
 
 ## 3. Comportamiento esperado
 
-* Participa de manera auténtica y activa. Al hacerlo, contribuyes a la salud y 
+* Participa de manera auténtica y activa. Al hacerlo, contribuyes a la salud y
 la longevidad de esta comunidad.
 * Ejercita la consideración y el respeto en tus comunicaciones y acciones.
 * Intenta colaborar en lugar de generar conflicto.
 * Absténte de adoptar una conducta y un lenguaje degradantes, discriminatorios,
 abusivos o acosadores.
-* Sé consciente de tu entorno y de tus compañeros participantes. Alerta a 
-líderes de la comunidad si notas una situación peligrosa, alguien en apuros, o 
+* Sé consciente de tu entorno y de tus compañeros participantes. Alerta a
+líderes de la comunidad si notas una situación peligrosa, alguien en apuros, o
 violaciones de este Código de Conducta, incluso si parecen intrascendentes.
 
 ## 4. Comportamiento inaceptable
 
 Comportamientos inaceptables incluyen: intimidación, acoso, abuso,
-discriminación, comunicación despectiva o degradante o acciones por cualquier 
-participante en nuestra comunidad ya sea en internet, en todos los eventos 
+discriminación, comunicación despectiva o degradante o acciones por cualquier
+participante en nuestra comunidad ya sea en internet, en todos los eventos
 relacionados y en las comunicaciones uno-a-uno que se realizan en el contexto de
 los negocios de la comunidad. Es posible que los lugares para eventos
-comunitarios sean de uso compartido con los miembros del público; por favor ser 
+comunitarios sean de uso compartido con los miembros del público; por favor ser
 respetuoso con todos aquellos que los frecuentan.
 
 El acoso incluye: comentarios nocivos o perjudiciales, verbales o escritos
-relacionados con el género, la orientación sexual, raza, religión, discapacidad; 
-uso inadecuado de desnudos y / o imágenes sexuales en espacios públicos 
-(incluyendo la presentación diapositivas); intimidación deliberada, acecho o 
+relacionados con el género, la orientación sexual, raza, religión, discapacidad;
+uso inadecuado de desnudos y / o imágenes sexuales en espacios públicos
+(incluyendo la presentación diapositivas); intimidación deliberada, acecho o
 seguimiento; fotografías o grabaciones acosadoras; interrupción sostenida de
-charlas y otros eventos; contacto físico inapropiado, y atención sexual no 
+charlas y otros eventos; contacto físico inapropiado, y atención sexual no
 deseada.
 
 ## 5. Consecuencias de comportamiento inaceptable
@@ -68,73 +68,73 @@ patrocinadores y aquellos con poder de decisión, no será tolerado.
 Se espera que personas a quienes se les solicite que detengan su comportamiento
 inaceptable lo hagan de manera inmediata.
 
-Si un miembro de la comunidad participa en una conducta inaceptable, los 
+Si un miembro de la comunidad participa en una conducta inaceptable, los
 organizadores comunitarios pueden tomar cualquier acción que consideren
-apropiada, hasta e incluyendo una prohibición temporal o expulsión permanente 
-de la comunidad, sin previo aviso (y sin derecho a reembolso en el caso de un 
+apropiada, hasta e incluyendo una prohibición temporal o expulsión permanente
+de la comunidad, sin previo aviso (y sin derecho a reembolso en el caso de un
 evento de pago).
 
 ## 6. Si usted es testigo o es objeto de comportamiento inaceptable
 
-Si eres víctima o testigo de una conducta inaceptable, o tienes cualquier 
-inquietud, por favor comunícate con un organizador del meetup lo antes posible. 
+Si eres víctima o testigo de una conducta inaceptable, o tienes cualquier
+inquietud, por favor comunícate con un organizador del meetup lo antes posible.
 
-Email: hola@colombia-dev.org
+Email: hola@peru-dev.org
 
 Adicionalmente, los organizadores comunitarios están disponibles para ayudar
 a miembros de la comunidad a contactar a la policía local o interceder para que
 víctimas de comportamiento inaceptable se sientan seguros,
 En el contexto de los eventos en persona, los organizadores
-también pueden proporcionar escoltas si un miembro de la comunidad lo siente 
+también pueden proporcionar escoltas si un miembro de la comunidad lo siente
 necesario.
 
 ## 7. Políticas de moderación
 
-Estas son las políticas para mantener los estándares de conducta en nuestra 
-comunidad en los canales de chat, meetups asociados, conferencias, 
+Estas son las políticas para mantener los estándares de conducta en nuestra
+comunidad en los canales de chat, meetups asociados, conferencias,
 grupos de estudio, y eventos virtuales.
 
-  * Palabras que violen las normas de Código de Conducta, incluyendo comentarios 
-    odiosos, hirientes, opresivos, o excluyentes, no están permitidos. (Se 
-    permite las "malas palabras", pero nunca enfocadas hacia otro 
+  * Palabras que violen las normas de Código de Conducta, incluyendo comentarios
+    odiosos, hirientes, opresivos, o excluyentes, no están permitidos. (Se
+    permite las "malas palabras", pero nunca enfocadas hacia otro
     usuario/asistente, y nunca de una manera odiosa.)
-  * Comentarios que los organizadores encuentran inapropiados tampoco están 
+  * Comentarios que los organizadores encuentran inapropiados tampoco están
     permitidos, así aparezcan en el código de conducta o no.
-  * Los organizadores primero deberán responder a dichos comentarios con una 
+  * Los organizadores primero deberán responder a dichos comentarios con una
     advertencia.
-  * Si la advertencia es ignorada, el usuario/asistente será expulsado del canal 
-    para que evalúe su comportamiento, o deberá retirarse del lugar por 30 
+  * Si la advertencia es ignorada, el usuario/asistente será expulsado del canal
+    para que evalúe su comportamiento, o deberá retirarse del lugar por 30
     minutos en caso de eventos presenciales.
-  * Si el usuario/asistente regresa y continúa causando problemas, será 
+  * Si el usuario/asistente regresa y continúa causando problemas, será
     expulsado del grupo/evento/lugar/Slack de forma indefinida.
-  * Los organizadores pueden retractar la expulsión a su discreción si esta se 
-    trata de una primera infracción y se ha ofrecido una disculpa sincera a 
+  * Los organizadores pueden retractar la expulsión a su discreción si esta se
+    trata de una primera infracción y se ha ofrecido una disculpa sincera a
     quien ofendieron.
-  * Si un organizador expulsa a alguien y usted cree que fue una expulsión sin 
-    causa, contacte a ese organizador, o a un organizador diferente 
-    **en privado**. Quejas sobre expulsiones en medios abiertos, sociales, u 
+  * Si un organizador expulsa a alguien y usted cree que fue una expulsión sin
+    causa, contacte a ese organizador, o a un organizador diferente
+    **en privado**. Quejas sobre expulsiones en medios abiertos, sociales, u
     otros canales no son permitidas y conllevaran a más expulsiones.
-  * Los organizadores se rigen por un nivel más alto que otros miembros de la 
-    comunidad. Si un organizador crea una situación inadecuada, este será 
+  * Los organizadores se rigen por un nivel más alto que otros miembros de la
+    comunidad. Si un organizador crea una situación inadecuada, este será
     juzgado con un estándar más alto.
 
-En la comunidad `colombia.dev` nos esforzamos por ir un paso más allá y cuidar 
-el uno del otro. No se limite a tratar de mostrar su excelencia técnica, trate 
-también de ser la mejor persona posible. En particular, evite tocar temas 
+En la comunidad `Perú Dev` nos esforzamos por ir un paso más allá y cuidar
+el uno del otro. No se limite a tratar de mostrar su excelencia técnica, trate
+también de ser la mejor persona posible. En particular, evite tocar temas
 ofensivos o sensibles, especialmente si están fuera del tema tratado; esto muy a
-menudo conduce a peleas innecesarias, sentimientos heridos, y a daños en la 
-confianza; peor aún, puede conducir a que personas se alejen de la comunidad en 
+menudo conduce a peleas innecesarias, sentimientos heridos, y a daños en la
+confianza; peor aún, puede conducir a que personas se alejen de la comunidad en
 su totalidad.
 
 De la misma forma, si alguien está en desacuerdo con algo que usted dijo o hizo,
 resista el impulso de estar a la defensiva. Simplemente pare de hacer o decir lo
 que fuera que causó la queja y pida disculpas. Hay buenas probabilidades de que
-usted se pudo haber comunicado mejor, incluso si usted siente que fue 
-malinterpretado o injustamente acusado, - recuerde que es su responsabilidad 
-hacer que sus compañeras y compañeros de `colombia.dev` estén cómodos.
+usted se pudo haber comunicado mejor, incluso si usted siente que fue
+malinterpretado o injustamente acusado, - recuerde que es su responsabilidad
+hacer que sus compañeras y compañeros de `Perú Dev` estén cómodos.
 
-Todo el mundo busca harmonía y todos estamos aquí, ante todo, porque queremos 
-hablar de tecnologías que nos gustan. Por lo general, la gente está dispuesta a 
+Todo el mundo busca harmonía y todos estamos aquí, ante todo, porque queremos
+hablar de tecnologías que nos gustan. Por lo general, la gente está dispuesta a
 asumir buenas intenciones y perdonar, siempre y cuando usted gane su confianza y
 actúe de forma honrada.
 
@@ -143,17 +143,18 @@ actúe de forma honrada.
 ## 8. Alcance
 
 Esperamos que todos los participantes de la comunidad (contribuyentes, pagados o
-de otro modo; patrocinadores; y otros invitados) se atengan a este Código de 
-Conducta en todos los espacios virtuales y presenciales, así como en todas las 
+de otro modo; patrocinadores; y otros invitados) se atengan a este Código de
+Conducta en todos los espacios virtuales y presenciales, así como en todas las
 comunicaciones de uno-a-uno pertinentes a los negocios de la comunidad.
 
 ## 9. Contacto
 
-- hola@colombia-dev.org
-- [@colombia_dev](https://twitter.com/colombia_dev)
+- hola@peru-dev.org
+- [@peru_dev](https://twitter.com/peru_dev)
 
 ## 10. Licencia y atribución
 
 Este Código de Conducta se distribuye bajo una licencia [Creative Commons – ShareAlike (BY-SA)](http://creativecommons.org/licenses/by-sa/3.0/)
 
-Adaptado del [Código de Conducta de Stumptown Syndicate](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md)
+Adaptado del [Código de Conducta de Stumptown Syndicate](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md) y
+[el de `colombia.dev`](https://github.com/colombia-dev/codigo-de-conducta).


### PR DESCRIPTION
Los cambios en este PR hacen referencia a un correo `hola@peru-dev.org`, que todavía no existe, y a una cuenta de [Twitter](https://twitter.com/peru_dev) que por ahora está inactiva y que administra @techfano.

Integrar este PR debería requerir que ocurra esto antes:

- [x] Crear cuenta de correo `hola@peru-dev.org` y que por lo menos 2 ó 3 personas tengan acceso, o alternativamente creer un correo gratuito (ie: `perudev@gmail.com`).
- [x] Poner logo en Twitter, y dar acceso a cuenta a 2 ó 3 personas para encargarse de la comunicación externa...